### PR TITLE
Fix JSON response

### DIFF
--- a/plugin.tcl
+++ b/plugin.tcl
@@ -58,7 +58,7 @@ namespace eval ::plugins::${plugin_name} {
 	proc ::wibble::return_200_json {content} {
 		dict set response status 200
 		dict set state response header content-type "" {application/json charset utf-8}
-		dict set response content "$content"
+		dict set response content "$content\n"
 		sendresponse $response
 	}
 	# from https://wiki.tcl-lang.org/page/JSON

--- a/plugin.tcl
+++ b/plugin.tcl
@@ -63,7 +63,7 @@ namespace eval ::plugins::${plugin_name} {
 	}
 	# from https://wiki.tcl-lang.org/page/JSON
 	proc ::wibble::compile_json {spec data} {
-      while [llength $spec] {
+      while {[llength $spec]} {
           set type [lindex $spec 0]
           set spec [lrange $spec 1 end]
 


### PR DESCRIPTION
- Add newline `\n` to HTTP response for better compatibility.
- Remove double substitution for while loop for better style.

Home assistant failed to extract the last value from the JSON payload with an added newline (might be a HA problem, still a newline at the and of JSON responses is good practice).