### PR TITLE
Set previous shot as next in DYE

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,6 +279,17 @@
               window.chart.update();
             });
       }
+    
+    function setAsNextShot() {
+      let selected = document.getElementById("shots").value;
+      if (!selected) {
+        return;
+      }
+      fetch(address + "/api/v2/shot/" + selected, { method: 'PUT' }).then(r => r.text())
+        .then(t => {
+          console.log(t);
+        })
+    }
 
     function loadSelectedProfile () {
       let selected = document.getElementById("profiles").value;
@@ -495,6 +506,7 @@
         </svg>
       </button>
       <button onclick="downloadShot()">Download Shot</button>
+      <button onclick="setAsNextShot()">Set as next in DYE</button>
       <!-- <span class="icon-search"></span> -->
       <br />
       <div style="max-width: 100%;">

--- a/index.html
+++ b/index.html
@@ -285,10 +285,16 @@
       if (!selected) {
         return;
       }
-      fetch(address + "/api/v2/shot/" + selected, { method: 'PUT' }).then(r => r.text())
-        .then(t => {
-          console.log(t);
-        })
+      fetch(address + "/api/v2/shot/" + selected, { method: 'PUT' }).then(response => {
+        if (response.status == 200) {
+          document.getElementById("modal-content").innerText = "Shot update successful"
+        }
+        else {
+          document.getElementById("modal-content").innerText = `Shot update error: ${response.statusText}`
+        }
+        document.getElementById("modal-control").checked = true;
+      })
+      .catch(error => alert(error.message));
     }
 
     function loadSelectedProfile () {

--- a/plugin.tcl
+++ b/plugin.tcl
@@ -212,6 +212,10 @@ namespace eval ::plugins::${plugin_name} {
     if { ![check_auth $state] } {
 			return;
 		}
+    set method [dict get $state request method]
+    if { $method eq "PUT" } {
+      return [set_next_shot_in_dye state]
+    }
 		set path [dict get $state request path]
 		set shot [lindex [split $path "/"] 4]
     append shotName [lindex [split $shot "."] 0] ".json"
@@ -224,6 +228,10 @@ namespace eval ::plugins::${plugin_name} {
 		} else {
       ::wibble::return_200_json
     }
+  }
+
+  proc ::wibble::set_next_shot_in_dye { state } {
+    ::wibble::return_200_json ""
   }
 
   proc ::wibble::history_sdb { state } {
@@ -406,7 +414,7 @@ namespace eval ::plugins::${plugin_name} {
 
 		::logging::flush_log
 
-		::wibble::return_200_json 
+		::wibble::return_200_json ""
 	}
 
 

--- a/plugin.tcl
+++ b/plugin.tcl
@@ -214,7 +214,7 @@ namespace eval ::plugins::${plugin_name} {
 		}
     set method [dict get $state request method]
     if { $method eq "PUT" } {
-      return [set_next_shot_in_dye state]
+      return [set_next_shot_in_dye $state]
     }
 		set path [dict get $state request path]
 		set shot [lindex [split $path "/"] 4]
@@ -231,6 +231,27 @@ namespace eval ::plugins::${plugin_name} {
   }
 
   proc ::wibble::set_next_shot_in_dye { state } {
+    set path [dict get $state request path]
+		set shot [lindex [split $path "/"] 4]
+    
+    msg -INFO "shot name is ${shot}"
+    
+    set fields {
+      workflow_settings
+      shot_profile
+      ratio
+      drink_weight
+      grinder_dose_weight 
+      grinder_setting 
+      grinder_model 
+      workflow
+      bean_brand
+      bean_type
+      roast_date
+      roast_level
+      bean_notes
+    }
+    ::plugins::DYE::shots::source_next_from $shot {} $fields
     ::wibble::return_200_json ""
   }
 

--- a/plugin.tcl
+++ b/plugin.tcl
@@ -309,9 +309,9 @@ namespace eval ::plugins::${plugin_name} {
 				dict set return "roast_date" $::settings(roast_date)
 				dict set return "roast_level" $::settings(roast_level)
 				dict set return "skin" [::profile::filename_from_title $::settings(skin)]
-				dict set return "head_temperature" $::de1(head_temperature)
-				dict set return "mix_temperature" $::de1(mix_temperature)
-				dict set return "steam_heater_temperature" $::de1(steam_heater_temperature)
+				dict set return "head_temperature" [expr [expr {floor([expr $::de1(head_temperature) * 100])} / 100]]
+				dict set return "mix_temperature" [expr [expr {floor([expr $::de1(mix_temperature) * 100])} / 100]]
+				dict set return "steam_heater_temperature" [expr [expr {floor([expr $::de1(steam_heater_temperature) * 100])} / 100]]
 				dict set return "water_level" [water_tank_level_to_milliliters $::de1(water_level)] [translate mL]
 			}
 			"Espresso" {


### PR DESCRIPTION
Adds button "Set as next in DYE" to set a previously brewed shot parameters be copied to the next shot instance in DYE.


Good for example when you want to brew a different coffee that you last had two days ago and don't exactly remember the grind/dose settings. Inspect the shot from your couch and then click "Set as next" and once you get to the machine, you can look at DYE screen and see exactly what your settings should be.

Also fixed api/flush response